### PR TITLE
Add build provenance attestation for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Build and Push Docker image for ${{ matrix.path }}
         if: ${{ matrix.path == 'docker' }}
+        id: build-docker
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:
           context: ./docker
@@ -72,6 +73,14 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}
+
+      - name: docker - Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.path == 'docker' }}
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-docker.outputs.digest }}
+          push-to-registry: true
 
       - name: Build and Push Docker image for ${{ matrix.path }}
         if: ${{ matrix.path == 'actions-runner-controller' }}
@@ -86,6 +95,14 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc:${{ steps.output-collector.outputs.output }}
 
+      - name: actions-runner-controller - Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.path == 'actions-runner-controller' }}
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc
+          subject-digest: ${{ steps.build-docker.outputs.digest }}
+          push-to-registry: true
+
       - name: Build and Push Docker image for ${{ matrix.path }}
         if: ${{ matrix.path == 'arc-container-dind' }}
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
@@ -98,3 +115,11 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc-container-dind:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc-container-dind:${{ steps.output-collector.outputs.output }}
+
+      - name: arc-container-dind - Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.path == 'arc-container-dind' }}
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-arc-container-dind
+          subject-digest: ${{ steps.build-docker.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-publish.yml` file, mainly to add build provenance attestation for Docker images. This is done by using the `actions/attest-build-provenance@v1` action for each Docker image build job. The changes also include adding an `id` to the Docker build step.