### PR TITLE
Update CI configuration for multiple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         path: [docker]
-    runs-on: ubuntu-latest
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,8 +18,9 @@ jobs:
     strategy:
       matrix:
         path: [docker]
+        platform: [ubuntu-latest, macos-latest]
     environment: publish
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request includes changes to the Continuous Integration (CI) workflow configuration files. The most significant changes are the addition of a new `platform` matrix to the job strategies and the update of the `runs-on` field to use the platform specified in the matrix. This allows the jobs to run on both `ubuntu-latest` and `macos-latest` platforms.