### PR TITLE
add actions-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
   build-actions-runner-image:
     env:
-      IMAGE_NAME: ${{ github.repository }}/actions-runner
+      IMAGE_NAME: actions-runner
     strategy:
       matrix:
         path: [docker]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,100 @@ jobs:
           subject-name: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}"
           subject-digest: "${{ steps.build-docker.outputs.digest }}"
           push-to-registry: false
+
+  build-actions-runner-image:
+    env:
+      IMAGE_NAME: ${{ github.repository }}/actions-runner
+    strategy:
+      matrix:
+        path: [docker]
+        os: [linux]
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+      - name: Output Collector
+        id: output-collector
+        uses: collinmcneese/file-output-collector@main
+        with:
+          file: "./VERSION"
+
+      - name: Prep
+        run: |
+          echo Building with Runner version ${{ steps.output-collector.outputs.output }}
+          echo ${{ steps.output-collector.outputs.output }} | grep 2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for ${{ matrix.path }}
+        if: ${{ matrix.path == 'docker' }}
+        id: meta-docker
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Extract metadata (tags, labels) for ${{ matrix.path }}
+        if: ${{ matrix.path == 'actions-runner-controller' }}
+        id: meta-arc
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build Docker image for ${{ matrix.path }}
+        if: ${{ matrix.path == 'docker' }}
+        id: build-docker
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+        with:
+          context: ./docker
+          push: false
+          labels: ${{ steps.meta-docker.outputs.labels }}
+          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
+          load: true
+          build-args: |
+            RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
+            TARGETOS=${{ matrix.os }}
+            TARGETARCH=${{ matrix.arch }}
+            RUNNER_CONTAINER_HOOKS_VERSION=0.6.0
+            DOCKER_VERSION=25.0.4
+            BUILDX_VERSION=0.13.1
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}
+
+      - name: debug build
+        run: |
+          echo "digest: ${{ steps.build-docker.outputs.digest }}"
+          echo "metadata: ${{ steps.build-docker.outputs.metadata }}"
+          echo "imageid: ${{ steps.build-docker.outputs.imageid }}"
+
+      - name: docker - Build Attestation
+        uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.path == 'docker' }}
+        with:
+          subject-name: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}"
+          subject-digest: "${{ steps.build-docker.outputs.digest }}"
+          push-to-registry: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,3 +92,101 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}
           subject-digest: ${{ steps.build-docker.outputs.digest }}
           push-to-registry: false
+
+
+  build-actions-runner-image:
+    env:
+      IMAGE_NAME: actions-runner
+    strategy:
+      matrix:
+        path: [docker]
+        os: [linux]
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+      - name: Output Collector
+        id: output-collector
+        uses: collinmcneese/file-output-collector@main
+        with:
+          file: "./VERSION"
+
+      - name: Prep
+        run: |
+          echo Building with Runner version ${{ steps.output-collector.outputs.output }}
+          echo ${{ steps.output-collector.outputs.output }} | grep 2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for ${{ matrix.path }}
+        if: ${{ matrix.path == 'docker' }}
+        id: meta-docker
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Extract metadata (tags, labels) for ${{ matrix.path }}
+        if: ${{ matrix.path == 'actions-runner-controller' }}
+        id: meta-arc
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build Docker image for ${{ matrix.path }}
+        if: ${{ matrix.path == 'docker' }}
+        id: build-docker
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
+        with:
+          context: ./docker
+          push: false
+          labels: ${{ steps.meta-docker.outputs.labels }}
+          platforms: "${{ matrix.os }}/${{ matrix.arch }}"
+          load: true
+          build-args: |
+            RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
+            TARGETOS=${{ matrix.os }}
+            TARGETARCH=${{ matrix.arch }}
+            RUNNER_CONTAINER_HOOKS_VERSION=0.6.0
+            DOCKER_VERSION=25.0.4
+            BUILDX_VERSION=0.13.1
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}
+
+      - name: debug build
+        run: |
+          echo "digest: ${{ steps.build-docker.outputs.digest }}"
+          echo "metadata: ${{ steps.build-docker.outputs.metadata }}"
+          echo "imageid: ${{ steps.build-docker.outputs.imageid }}"
+
+      - name: docker - Build Attestation
+        uses: actions/attest-build-provenance@v1
+        if: ${{ matrix.path == 'docker' }}
+        with:
+          subject-name: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.output-collector.outputs.output }}"
+          subject-digest: "${{ steps.build-docker.outputs.digest }}"
+          push-to-registry: false


### PR DESCRIPTION
This pull request primarily includes a significant addition to the `.github/workflows/ci.yml` file. A new job named `build-actions-runner-image` has been added to the workflow. This job is responsible for building a Docker image for the GitHub Actions runner. The job is set to run on an Ubuntu-latest environment and includes a variety of steps, such as checking out the repository, setting up QEMU and Docker Buildx, logging into the container registry, extracting metadata, and building the Docker image. 