### PR TITLE
Add support for multi-architecture builds in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ env:
 
 jobs:
   build-docker-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -37,9 +42,6 @@ jobs:
         run: |
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -64,9 +66,6 @@ jobs:
           context: ./docker
           push: false
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
           tags: |
@@ -90,7 +89,12 @@ jobs:
   build-actions-runner-image:
     env:
       IMAGE_NAME: collinmcneese/actions-runner
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -117,9 +121,6 @@ jobs:
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -143,9 +144,6 @@ jobs:
           context: ./actions-runner
           push: false
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
             RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
@@ -172,7 +170,12 @@ jobs:
   build-runner-no-dind-image:
     env:
       IMAGE_NAME: collinmcneese/runner-no-dind
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -199,9 +202,6 @@ jobs:
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -225,9 +225,6 @@ jobs:
           context: ./runner-no-dind
           push: false
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
             RUNNER_CONTAINER_HOOKS_VERSION=0.6.1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,12 @@ env:
 
 jobs:
   build-docker-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     environment: publish
     permissions:
       contents: read
@@ -39,9 +44,6 @@ jobs:
         run: |
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,9 +68,6 @@ jobs:
           context: ./docker
           push: true
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
           tags: |
@@ -92,7 +91,12 @@ jobs:
   build-actions-runner-image:
     env:
       IMAGE_NAME: collinmcneese/actions-runner
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     environment: publish
     permissions:
       contents: read
@@ -114,9 +118,6 @@ jobs:
         run: |
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -141,9 +142,6 @@ jobs:
           context: ./actions-runner
           push: true
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
             RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
@@ -170,7 +168,12 @@ jobs:
   build-runner-no-dind-image:
     env:
       IMAGE_NAME: collinmcneese/runner-no-dind
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     environment: publish
     permissions:
       contents: read
@@ -192,9 +195,6 @@ jobs:
         run: |
           echo Building with Runner version ${{ steps.output-collector.outputs.output }}
           echo ${{ steps.output-collector.outputs.output }} | grep 2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -219,9 +219,6 @@ jobs:
           context: ./runner-no-dind
           push: true
           labels: ${{ steps.meta-docker.outputs.labels }}
-          platforms: |
-            linux/amd64
-            linux/arm64
           build-args: |
             RUNNER_VERSION=${{ steps.output-collector.outputs.output }}
             RUNNER_CONTAINER_HOOKS_VERSION=0.6.1


### PR DESCRIPTION
Enhancements to CI workflow:

* Introduced a matrix strategy to run jobs on multiple operating systems (`ubuntu-latest` and `ubuntu-24.04-arm`). This change affects the `build-docker-image`, `build-actions-runner-image`, and `build-runner-no-dind-image` jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL14-R19) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL93-R97) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL175-R178)
* Removed the setup of QEMU as it is no longer needed for the specified platforms. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL41-L43) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL120-L122) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL202-L204)

Simplification of build configurations:

* Removed the `platforms` specification from the Docker build steps, as the matrix strategy now handles the different architectures. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL67-L69) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL146-L148) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL228-L230)